### PR TITLE
GRRLIB_ttf.c: DrawBitmap: Use less GX_Begin/GX_End calls

### DIFF
--- a/GRRLIB/GRRLIB/GRRLIB_ttf.c
+++ b/GRRLIB/GRRLIB/GRRLIB_ttf.c
@@ -175,15 +175,15 @@ static void DrawBitmap(FT_Bitmap *bitmap, int offset, int top, const u8 cR, cons
     FT_Int x_max = offset + bitmap->width;
     FT_Int y_max = top + bitmap->rows;
 
+    GX_Begin(GX_POINTS, GX_VTXFMT0, (x_max - offset) * (y_max - top));
     for ( i = offset, p = 0; i < x_max; i++, p++ ) {
         for ( j = top, q = 0; j < y_max; j++, q++ ) {
-            GX_Begin(GX_POINTS, GX_VTXFMT0, 1);
-                GX_Position3f32(i, j, 0);
-                GX_Color4u8(cR, cG, cB,
-                            bitmap->buffer[ q * bitmap->width + p ]);
-            GX_End();
+            GX_Position3f32(i, j, 0);
+            GX_Color4u8(cR, cG, cB,
+                        bitmap->buffer[ q * bitmap->width + p ]);
         }
     }
+    GX_End();
 }
 
 /**


### PR DESCRIPTION
Untested. Works only for bitmaps up to 256x256 pixels due to the [upper limit of 65536](http://libogc.devkitpro.org/gx_8h.html#ac1e1239130a33d9fae1352aee8d2cab9) of the last parameter to `GX_Begin()`. This could be fixed by batching things up in 65536 chunks (adding a `GX_Begin()`/`GX_End()` pair into the vertex stream every 65536 vertices), but then again, the performance for 256x256-sized glyphs is probably not that good, anyway.