### PR TITLE
Fix issue with GRRLIB_DrawImg

### DIFF
--- a/GRRLIB/GRRLIB/GRRLIB_render.c
+++ b/GRRLIB/GRRLIB/GRRLIB_render.c
@@ -67,8 +67,8 @@ void  GRRLIB_DrawImg (const f32 xpos, const f32 ypos, const GRRLIB_texImg *tex, 
     guMtxRotAxisDeg(m2, &axis, degrees);
     guMtxConcat    (m2, m1, m);
 
-    const u32 width  = tex->w * 0.5;
-    const u32 height = tex->h * 0.5;
+    const f32 width  = tex->w * 0.5;
+    const f32 height = tex->h * 0.5;
 
     guMtxTransApply(m, m,
         xpos +width  +tex->handlex


### PR DESCRIPTION
# Problem description

`GRRLIB_DrawImg` is displaying garbage data / nothing on real Wii hardware.

# Versions used

```
$ powerpc-eabi-gcc --version

powerpc-eabi-gcc (devkitPPC release 41) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

# Fix description

Looking at both implementation of `GRRLIB_DrawTile` (which was working) and `GRRLIB_DrawImg`, I found that `width` and `height` are not defined as `f32`.

Changing variable type fix the issue.