### PR TITLE
Remove links to Gitter, IRC and the old forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ﻿# GRRLIB
 
-[![Continuous Integration](https://github.com/GRRLIB/GRRLIB/workflows/Continuous%20Integration/badge.svg)](https://github.com/GRRLIB/GRRLIB/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/GRRLIB/GRRLIB/ci.yml?logo=github)](https://github.com/GRRLIB/GRRLIB/actions)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/02847b348a1e4e6b850f956541ef2361)](https://app.codacy.com/gh/GRRLIB/GRRLIB/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Join the chat at https://gitter.im/GRRLIB/GRRLIB](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/GRRLIB/GRRLIB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![GitHub Discussions](https://img.shields.io/github/discussions/GRRLIB/GRRLIB?logo=github)](https://github.com/GRRLIB/GRRLIB/discussions)
+[![Static Badge](https://img.shields.io/badge/code-documented-brightgreen)](https://grrlib.github.io/GRRLIB)
 
 ## Table of Contents
 

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -10,8 +10,7 @@
  *
  * @section Links
  * Code: https://github.com/GRRLIB/GRRLIB\n
- * Discussions: http://grrlib.santo.fr/forum\n
- * Chat: <a href="irc://irc.efnet.net/grrlib">\#GRRLIB</a> on EFnet
+ * Discussions: https://github.com/GRRLIB/GRRLIB/discussions\n
  *
  * @section Credits
  * Project Leader : NoNameNo\n


### PR DESCRIPTION
Remove links to [Gitter](https://gitter.im/GRRLIB/GRRLIB), IRC (irc://irc.efnet.net/grrlib) and the [old forum](http://grrlib.santo.fr/forum).

The best way to communicate with us is through [GitHub Discussions](https://github.com/GRRLIB/GRRLIB/discussions).