### PR TITLE
Allow different texture format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased][]
 
-- TODO
+- Added `GRRLIB_CreateEmptyTextureFmt()` to create an empty texture with a given format.
 
 ## [4.5.1][] - 2024-03-02
 

--- a/GRRLIB/GRRLIB/GRRLIB_3D.c
+++ b/GRRLIB/GRRLIB/GRRLIB_3D.c
@@ -347,10 +347,10 @@ void GRRLIB_SetTexture(GRRLIB_texImg *tex, bool rep) {
     GXTexObj  texObj;
 
     if (rep == true) {
-        GX_InitTexObj(&texObj, tex->data, tex->w, tex->h, GX_TF_RGBA8, GX_REPEAT, GX_REPEAT, GX_FALSE);
+        GX_InitTexObj(&texObj, tex->data, tex->w, tex->h, tex->format, GX_REPEAT, GX_REPEAT, GX_FALSE);
     }
     else {
-        GX_InitTexObj(&texObj, tex->data, tex->w, tex->h, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+        GX_InitTexObj(&texObj, tex->data, tex->w, tex->h, tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
     }
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR, 0.0f, 0.0f, 0.0f, 0, 0, GX_ANISO_1);

--- a/GRRLIB/GRRLIB/GRRLIB_render.c
+++ b/GRRLIB/GRRLIB/GRRLIB_render.c
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------------
-Copyright (c) 2009-2022 The GRRLIB Team
+Copyright (c) 2009-2024 The GRRLIB Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -47,7 +47,7 @@ void  GRRLIB_DrawImg (const f32 xpos, const f32 ypos, const GRRLIB_texImg *tex, 
         return;
 
     GX_InitTexObj(&texObj, tex->data, tex->w, tex->h,
-                  GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+                  tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR,
@@ -118,7 +118,7 @@ void  GRRLIB_DrawImgQuad (const guVector pos[4], GRRLIB_texImg *tex, const u32 c
         return;
 
     GX_InitTexObj(&texObj, tex->data, tex->w, tex->h,
-                  GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+                  tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR,
@@ -189,7 +189,7 @@ void  GRRLIB_DrawTile (const f32 xpos, const f32 ypos, const GRRLIB_texImg *tex,
 
     GX_InitTexObj(&texObj, tex->data,
                   tex->tilew * tex->nbtilew, tex->tileh * tex->nbtileh,
-                  GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+                  tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR,
@@ -276,7 +276,7 @@ void  GRRLIB_DrawPart (const f32 xpos, const f32 ypos, const f32 partx, const f3
 
     GX_InitTexObj(&texObj, tex->data,
                   tex->w, tex->h,
-                  GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+                  tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR,
@@ -356,7 +356,7 @@ void  GRRLIB_DrawTileQuad (const guVector pos[4], GRRLIB_texImg *tex, const u32 
 
     GX_InitTexObj(&texObj, tex->data,
                   tex->tilew * tex->nbtilew, tex->tileh * tex->nbtileh,
-                  GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+                  tex->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (GRRLIB_Settings.antialias == false) {
         GX_InitTexObjLOD(&texObj, GX_NEAR, GX_NEAR,

--- a/GRRLIB/GRRLIB/GRRLIB_snapshot.c
+++ b/GRRLIB/GRRLIB/GRRLIB_snapshot.c
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------------
-Copyright (c) 2009-2022 The GRRLIB Team
+Copyright (c) 2009-2024 The GRRLIB Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ void  GRRLIB_Screen2Texture (u16 posx, u16 posy, GRRLIB_texImg *tex, bool clear)
         return;
     }
     GX_SetTexCopySrc(posx, posy, tex->w, tex->h);
-    GX_SetTexCopyDst(tex->w, tex->h, GX_TF_RGBA8, GX_FALSE);
+    GX_SetTexCopyDst(tex->w, tex->h, tex->format, GX_FALSE);
     GX_CopyTex(tex->data, GX_FALSE);
     GX_PixModeSync();
     GRRLIB_FlushTex(tex);

--- a/GRRLIB/GRRLIB/GRRLIB_texEdit.c
+++ b/GRRLIB/GRRLIB/GRRLIB_texEdit.c
@@ -105,27 +105,42 @@ void  RawTo4x4RGBA (const u8 *src, void *dst,
 }
 
 /**
- * Create an empty texture.
+ * Create an empty texture with a given format.
+ * @param width Width of the new texture to create.
+ * @param height Height of the new texture to create.
+ * @param format Format of the new texture to create.
+ * @return A GRRLIB_texImg structure newly created.
+ */
+GRRLIB_texImg*  GRRLIB_CreateEmptyTextureFmt (const u32 width, const u32 height, const u32 format)
+{
+    GRRLIB_texImg *my_texture = (struct GRRLIB_texImg *)calloc(1, sizeof(GRRLIB_texImg));
+
+    if (my_texture != NULL) {
+        const u32 buffsize = GX_GetTexBufferSize(width, height, format, 0, 0);
+
+        my_texture->data = memalign(32, buffsize);
+        my_texture->w = width;
+        my_texture->h = height;
+        my_texture->format = format;
+
+        // Initialize the texture
+        memset(my_texture->data, '\0', buffsize);
+
+        GRRLIB_SetHandle(my_texture, 0, 0);
+        GRRLIB_FlushTex(my_texture);
+    }
+    return my_texture;
+}
+
+/**
+ * Create an empty texture in GX_TF_RGBA8 format.
  * @param width Width of the new texture to create.
  * @param height Height of the new texture to create.
  * @return A GRRLIB_texImg structure newly created.
  */
 GRRLIB_texImg*  GRRLIB_CreateEmptyTexture (const u32 width, const u32 height)
 {
-    GRRLIB_texImg *my_texture = (struct GRRLIB_texImg *)calloc(1, sizeof(GRRLIB_texImg));
-
-    if (my_texture != NULL) {
-        my_texture->data = memalign(32, height * width * 4);
-        my_texture->w = width;
-        my_texture->h = height;
-
-        // Initialize the texture
-        memset(my_texture->data, '\0', (height * width) << 2);
-
-        GRRLIB_SetHandle(my_texture, 0, 0);
-        GRRLIB_FlushTex(my_texture);
-    }
-    return my_texture;
+    return GRRLIB_CreateEmptyTextureFmt(width, height, GX_TF_RGBA8);
 }
 
 /**
@@ -164,6 +179,7 @@ GRRLIB_texImg*  GRRLIB_LoadTexturePNG (const u8 *my_png) {
     if (my_texture->data != NULL) {
         my_texture->w = width;
         my_texture->h = height;
+        my_texture->format = GX_TF_RGBA8;
         GRRLIB_SetHandle( my_texture, 0, 0 );
         if (imgProp.imgWidth != width || imgProp.imgHeight != height) {
             // PNGU has resized the texture
@@ -236,6 +252,7 @@ GRRLIB_texImg*  GRRLIB_LoadTextureBMP (const u8 *my_bmp) {
         RGBQUAD *Palette;
         my_texture->w = MyBitmapHeader.biWidth;
         my_texture->h = MyBitmapHeader.biHeight;
+        my_texture->format = GX_TF_RGBA8;
         switch(MyBitmapHeader.biBitCount) {
             case 32:    // RGBA images
                 i = 54;
@@ -407,6 +424,7 @@ GRRLIB_texImg*  GRRLIB_LoadTextureJPGEx (const u8 *my_jpg, const u32 my_size) {
 
     my_texture->w = cinfo.output_width;
     my_texture->h = cinfo.output_height;
+    my_texture->format = GX_TF_RGBA8;
     GRRLIB_SetHandle( my_texture, 0, 0 );
     GRRLIB_FlushTex( my_texture );
     return my_texture;

--- a/GRRLIB/GRRLIB/grrlib.h
+++ b/GRRLIB/GRRLIB/grrlib.h
@@ -107,6 +107,7 @@ typedef  struct GRRLIB_drawSettings {
 typedef  struct GRRLIB_texImg {
     u32    w;           /**< The width of the texture in pixels.  */
     u32    h;           /**< The height of the texture in pixels. */
+    u32    format;      /**< Texture format. */
     int    handlex;     /**< Texture handle x. */
     int    handley;     /**< Texture handle y. */
     int    offsetx;     /**< Texture offset x. */

--- a/GRRLIB/GRRLIB/grrlib/GRRLIB__lib.h
+++ b/GRRLIB/GRRLIB/grrlib/GRRLIB__lib.h
@@ -136,6 +136,7 @@ void  GRRLIB_CompoEnd(u16 posx, u16 posy, GRRLIB_texImg *tex);
 //------------------------------------------------------------------------------
 // GRRLIB_texEdit.c - Modifying the content of a texture
 GRRLIB_texImg*  GRRLIB_CreateEmptyTexture (const u32 width, const u32 height);
+GRRLIB_texImg*  GRRLIB_CreateEmptyTextureFmt (const u32 width, const u32 height, const u32 format);
 GRRLIB_texImg*  GRRLIB_LoadTexture    (const u8 *my_img);
 GRRLIB_texImg*  GRRLIB_LoadTexturePNG (const u8 *my_png);
 GRRLIB_texImg*  GRRLIB_LoadTextureJPG (const u8 *my_jpg);

--- a/GRRLIB/GRRLIB/grrlib/GRRLIB_texSetup.h
+++ b/GRRLIB/GRRLIB/grrlib/GRRLIB_texSetup.h
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------------
-Copyright (c) 2009-2021 The GRRLIB Team
+Copyright (c) 2009-2024 The GRRLIB Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ THE SOFTWARE.
  */
 INLINE
 void  GRRLIB_FlushTex (GRRLIB_texImg *tex) {
-    DCFlushRange(tex->data, tex->w * tex->h * 4);
+    DCFlushRange(tex->data, GX_GetTexBufferSize(tex->w, tex->h, tex->format, 0, 0));
 }
 
 /**
@@ -61,6 +61,9 @@ void  GRRLIB_FreeTexture (GRRLIB_texImg *tex) {
  */
 INLINE
 void  GRRLIB_ClearTex(GRRLIB_texImg* tex) {
-    memset(tex->data, 0, (tex->h * tex->w) << 2);
+    if(tex == NULL) {
+        return;
+    }
+    memset(tex->data, 0, GX_GetTexBufferSize(tex->w, tex->h, tex->format, 0, 0));
     GRRLIB_FlushTex(tex);
 }

--- a/examples/NEED_GRRLIB_FUNCTION/source/main.c
+++ b/examples/NEED_GRRLIB_FUNCTION/source/main.c
@@ -46,7 +46,7 @@ int main() {
 
         GRRLIB_2dMode();
         WPAD_ScanPads();
-        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME) exit(0);
+        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME) break;
         if(WPAD_ButtonsDown(0) & WPAD_BUTTON_PLUS && demo < 5) demo++;
         if(WPAD_ButtonsDown(0) & WPAD_BUTTON_MINUS && demo > 0) demo--;
 

--- a/examples/gamecube/unlimited2d/source/main.c
+++ b/examples/gamecube/unlimited2d/source/main.c
@@ -16,7 +16,6 @@
 
 
 int main() {
-    int i;
     int screen_index = 0;
     const int tex_screen_count = 3;
     float t = 0;
@@ -35,8 +34,8 @@ int main() {
     GRRLIB_Settings.antialias = false;
 
     GRRLIB_texImg *tex_screen[tex_screen_count];
-    for(i=0; i<tex_screen_count; i++) {
-        tex_screen[i] = GRRLIB_CreateEmptyTexture(rmode->fbWidth, rmode->efbHeight);
+    for(int i=0; i<tex_screen_count; i++) {
+        tex_screen[i] = GRRLIB_CreateEmptyTextureFmt(rmode->fbWidth, rmode->efbHeight, GX_TF_RGB565);
     }
 
     GRRLIB_texImg *tex_ball = GRRLIB_LoadTexture(ball_png);
@@ -45,14 +44,14 @@ int main() {
     GRRLIB_InitTileSet(tex_font, 16, 16, 32);
 
 
-    for(i=0; i<=255; i+=1) {
+    for(int i=0; i<=255; i+=1) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY SPRITES");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
         GRRLIB_Printf((640-(16*28))/2, 480-16, tex_font, 0xFFFFFF00|i, 1, "BY NONAMENO FROM GRRLIB TEAM");
         GRRLIB_Render();
     }
-    for(i=255; i>=0; i-=2) {
+    for(int i=255; i>=0; i-=2) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY SPRITES");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
@@ -86,13 +85,13 @@ int main() {
         }
 
 
-        if(PAD_ButtonsDown(0) & PAD_BUTTON_START) exit(0);
-
+        if(PAD_ButtonsDown(0) & PAD_BUTTON_START)
+            break;
     }
     GRRLIB_FreeTexture(tex_logo);
     GRRLIB_FreeTexture(tex_ball);
     GRRLIB_FreeTexture(tex_font);
-    for(i=0; i<tex_screen_count; i++) {
+    for(int i=0; i<tex_screen_count; i++) {
         GRRLIB_FreeTexture(tex_screen[i]);
     }
     GRRLIB_Exit(); // Be a good boy, clear the memory allocated by GRRLIB

--- a/examples/gamecube/unlimited3d/source/main.c
+++ b/examples/gamecube/unlimited3d/source/main.c
@@ -16,7 +16,6 @@
 
 
 int main() {
-    int i;
     int screen_index = 0;
     const int tex_screen_count = 3;
     float t=0;
@@ -37,8 +36,8 @@ int main() {
     GRRLIB_Settings.antialias = false;
 
     GRRLIB_texImg *tex_screen[tex_screen_count];
-    for(i=0; i<tex_screen_count; i++) {
-        tex_screen[i] = GRRLIB_CreateEmptyTexture(rmode->fbWidth, rmode->efbHeight);
+    for(int i=0; i<tex_screen_count; i++) {
+        tex_screen[i] = GRRLIB_CreateEmptyTextureFmt(rmode->fbWidth, rmode->efbHeight, GX_TF_RGB565);
     }
 
     GRRLIB_texImg *tex_girl = GRRLIB_LoadTexture(girl_png);
@@ -47,14 +46,14 @@ int main() {
     GRRLIB_InitTileSet(tex_font, 16, 16, 32);
 
 
-    for(i=0; i<=255; i+=1) {
+    for(int i=0; i<=255; i+=1) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY 3D CUBE");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
         GRRLIB_Printf((640-(16*28))/2, 480-16, tex_font, 0xFFFFFF00|i, 1, "BY NONAMENO FROM GRRLIB TEAM");
         GRRLIB_Render();
     }
-    for(i=255; i>=0; i-=2) {
+    for(int i=255; i>=0; i-=2) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY 3D CUBE");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
@@ -182,12 +181,13 @@ int main() {
         }
 
 
-        if(PAD_ButtonsDown(0) & PAD_BUTTON_START) exit(0);
+        if(PAD_ButtonsDown(0) & PAD_BUTTON_START)
+            break;
     }
     GRRLIB_FreeTexture(tex_logo);
     GRRLIB_FreeTexture(tex_girl);
     GRRLIB_FreeTexture(tex_font);
-    for(i=0; i<tex_screen_count; i++) {
+    for(int i=0; i<tex_screen_count; i++) {
         GRRLIB_FreeTexture(tex_screen[i]);
     }
     GRRLIB_Exit(); // Be a good boy, clear the memory allocated by GRRLIB

--- a/examples/unlimited2d/source/main.c
+++ b/examples/unlimited2d/source/main.c
@@ -16,7 +16,6 @@
 
 
 int main() {
-    int i;
     int screen_index = 0;
     const int tex_screen_count = 10;
     float t = 0;
@@ -35,8 +34,8 @@ int main() {
     GRRLIB_Settings.antialias = false;
 
     GRRLIB_texImg *tex_screen[tex_screen_count];
-    for(i=0; i<tex_screen_count; i++) {
-        tex_screen[i] = GRRLIB_CreateEmptyTexture(rmode->fbWidth, rmode->efbHeight);
+    for(int i=0; i<tex_screen_count; i++) {
+        tex_screen[i] = GRRLIB_CreateEmptyTextureFmt(rmode->fbWidth, rmode->efbHeight, GX_TF_RGBA8);
     }
 
     GRRLIB_texImg *tex_ball = GRRLIB_LoadTexture(ball_png);
@@ -45,14 +44,14 @@ int main() {
     GRRLIB_InitTileSet(tex_font, 16, 16, 32);
 
 
-    for(i=0; i<=255; i+=1) {
+    for(int i=0; i<=255; i+=1) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY SPRITES");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
         GRRLIB_Printf((640-(16*28))/2, 480-16, tex_font, 0xFFFFFF00|i, 1, "BY NONAMENO FROM GRRLIB TEAM");
         GRRLIB_Render();
     }
-    for(i=255; i>=0; i-=2) {
+    for(int i=255; i>=0; i-=2) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY SPRITES");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
@@ -86,13 +85,13 @@ int main() {
         }
 
 
-        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME) exit(0);
-
+        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME)
+            break;
     }
     GRRLIB_FreeTexture(tex_logo);
     GRRLIB_FreeTexture(tex_ball);
     GRRLIB_FreeTexture(tex_font);
-    for(i=0; i<tex_screen_count; i++) {
+    for(int i=0; i<tex_screen_count; i++) {
         GRRLIB_FreeTexture(tex_screen[i]);
     }
     GRRLIB_Exit(); // Be a good boy, clear the memory allocated by GRRLIB

--- a/examples/unlimited3d/source/main.c
+++ b/examples/unlimited3d/source/main.c
@@ -16,7 +16,6 @@
 
 
 int main() {
-    int i;
     int screen_index = 0;
     const int tex_screen_count = 9;
     float t=0;
@@ -37,8 +36,8 @@ int main() {
     GRRLIB_Settings.antialias = false;
 
     GRRLIB_texImg *tex_screen[tex_screen_count];
-    for(i=0; i<tex_screen_count; i++) {
-        tex_screen[i] = GRRLIB_CreateEmptyTexture(rmode->fbWidth, rmode->efbHeight);
+    for(int i=0; i<tex_screen_count; i++) {
+        tex_screen[i] = GRRLIB_CreateEmptyTextureFmt(rmode->fbWidth, rmode->efbHeight, GX_TF_RGBA8);
     }
 
     GRRLIB_texImg *tex_girl = GRRLIB_LoadTexture(girl_png);
@@ -47,14 +46,14 @@ int main() {
     GRRLIB_InitTileSet(tex_font, 16, 16, 32);
 
 
-    for(i=0; i<=255; i+=1) {
+    for(int i=0; i<=255; i+=1) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY 3D CUBE");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
         GRRLIB_Printf((640-(16*28))/2, 480-16, tex_font, 0xFFFFFF00|i, 1, "BY NONAMENO FROM GRRLIB TEAM");
         GRRLIB_Render();
     }
-    for(i=255; i>=0; i-=2) {
+    for(int i=255; i>=0; i-=2) {
         GRRLIB_Printf((640-(16*16))/2, 200, tex_font, 0xFFFFFF00|i, 1, "HOW MANY 3D CUBE");
         GRRLIB_Printf((640-(16*20))/2, 216, tex_font, 0xFFFFFF00|i, 1, "CAN YOU DISPLAY WITH");
         GRRLIB_DrawImg((640-352)/2, 248, tex_logo, 0, 1, 1, 0xFFFFFF00|i);
@@ -182,12 +181,13 @@ int main() {
         }
 
 
-        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME) exit(0);
+        if(WPAD_ButtonsDown(0) & WPAD_BUTTON_HOME)
+            break;
     }
     GRRLIB_FreeTexture(tex_logo);
     GRRLIB_FreeTexture(tex_girl);
     GRRLIB_FreeTexture(tex_font);
-    for(i=0; i<tex_screen_count; i++) {
+    for(int i=0; i<tex_screen_count; i++) {
         GRRLIB_FreeTexture(tex_screen[i]);
     }
     GRRLIB_Exit(); // Be a good boy, clear the memory allocated by GRRLIB


### PR DESCRIPTION
Allow different texture format.

Added `GRRLIB_CreateEmptyTextureFmt()` to create an empty texture with a given format.